### PR TITLE
Use the go4.org/mem package to reduce allocations.

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -3,136 +3,22 @@
 package jtree
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
-	"unicode/utf8"
+	"github.com/creachadair/jtree/internal/escape"
+
+	"go4.org/mem"
 )
 
-var controlEsc = [...]byte{
-	'\b': 'b',
-	'\f': 'f',
-	'\n': 'n',
-	'\r': 'r',
-	'\t': 't',
-	' ':  ' ', // sentinel
+// Quote encodes a string to escape characters for inclusion in a JSON string.
+func Quote(src string) []byte {
+	return escape.Quote(mem.S(src))
 }
 
-var hexDigit = []byte("0123456789abcdef")
-
-// Escape encodes a string to escape characters for inclusion in a JSON string.
-func Escape(src string) []byte {
-	var buf bytes.Buffer
-	for _, r := range src {
-		if r < utf8.RuneSelf {
-			if r < ' ' {
-				buf.WriteByte('\\')
-				if b := controlEsc[r]; b != 0 {
-					buf.WriteByte(b)
-				} else {
-					buf.WriteString("u00")
-					buf.WriteByte(hexDigit[int(r>>4)])
-					buf.WriteByte(hexDigit[int(r&15)])
-				}
-				continue
-			} else if r == '\\' || r == '"' {
-				buf.WriteByte('\\')
-			}
-			buf.WriteByte(byte(r))
-			continue
-		}
-
-		switch r {
-		case '\ufffd': // replacement rune
-			buf.WriteString(`\ufffd`)
-		case '\u2028': // line separator
-			buf.WriteString(`\u2028`)
-		case '\u2029': // paragraph separator
-			buf.WriteString(`\u2029`)
-		default:
-			buf.WriteRune(r)
-		}
-	}
-	return buf.Bytes()
-}
-
-// Unescape decodes a byte slice containing the JSON encoding of a string. The
+// Unquote decodes a byte slice containing the JSON encoding of a string. The
 // input must have the enclosing double quotation marks already removed.
 //
 // Escape sequences are replaced with their unescaped equivalents. Invalid
-// escapes are replaced by the Unicode replacement rune. Unescape reports an
+// escapes are replaced by the Unicode replacement rune. Unquote reports an
 // error for an incomplete escape sequence.
-func Unescape(src []byte) ([]byte, error) {
-	if !bytes.ContainsRune(src, '\\') {
-		return src, nil
-	}
-
-	dec := bytes.NewBuffer(make([]byte, 0, len(src)))
-	for len(src) != 0 {
-		i := bytes.IndexRune(src, '\\')
-		if i < 0 {
-			dec.Write(src)
-			break
-		}
-		dec.Write(src[:i])
-
-		// Decode the next rune after the escape to figure out what to
-		// substitute. There should not be errors here, but if there are, insert
-		// replacement runes (utf8.RuneError == '\ufffd').
-		src = src[i+1:]
-		if len(src) == 0 {
-			return nil, errors.New("incomplete escape sequence")
-		}
-		r, n := utf8.DecodeRune(src)
-		if n == 0 {
-			n++
-		}
-
-		src = src[n:]
-		switch r {
-		case '"', '\\', '/':
-			dec.WriteByte(byte(r))
-		case 'b':
-			dec.WriteByte('\b')
-		case 'f':
-			dec.WriteByte('\f')
-		case 'n':
-			dec.WriteByte('\n')
-		case 'r':
-			dec.WriteByte('\r')
-		case 't':
-			dec.WriteByte('\t')
-		case 'u':
-			if len(src) < 4 {
-				return nil, errors.New("incomplete Unicode escape")
-			}
-			v, err := parseHex(src[:4])
-			if err != nil {
-				dec.WriteRune(utf8.RuneError)
-			} else {
-				dec.WriteRune(rune(v))
-			}
-			src = src[4:]
-		default:
-			dec.WriteRune(utf8.RuneError)
-		}
-	}
-	return dec.Bytes(), nil
-}
-
-func parseHex(data []byte) (int64, error) {
-	var v int64
-	for _, b := range data {
-		v <<= 4
-		if '0' <= b && b <= '9' {
-			v += int64(b - '0')
-		} else if 'a' <= b && b <= 'f' {
-			v += int64(b - 'a' + 10)
-		} else if 'A' <= b && b <= 'F' {
-			v += int64(b - 'A' + 10)
-		} else {
-			return 0, fmt.Errorf("invalid hex digit %q", b)
-		}
-	}
-	return v, nil
+func Unquote(src []byte) ([]byte, error) {
+	return escape.Unquote(mem.B(src))
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/creachadair/jtree
 
 go 1.18
 
-require github.com/google/go-cmp v0.5.6
+require (
+	github.com/google/go-cmp v0.5.6
+	go4.org/mem v0.0.0-20220726221520-4f986261bf13
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+go4.org/mem v0.0.0-20220726221520-4f986261bf13 h1:CbZeCBZ0aZj8EfVgnqQcYZgf0lpZ3H9rmp5nkDTAst8=
+go4.org/mem v0.0.0-20220726221520-4f986261bf13/go.mod h1:reUoABIJ9ikfM5sgtSF3Wushcza7+WeD01VB9Lirh3g=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/escape/quote.go
+++ b/internal/escape/quote.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2023 Michael J. Fromberger. All Rights Reserved.
+
+package escape
+
+import (
+	"unicode/utf8"
+
+	"go4.org/mem"
+)
+
+var controlEsc = [...]byte{
+	'\b': 'b',
+	'\f': 'f',
+	'\n': 'n',
+	'\r': 'r',
+	'\t': 't',
+	' ':  ' ', // sentinel
+}
+
+var hexDigit = []byte("0123456789abcdef")
+
+// Quote encodes a string to escape characters for inclusion in a JSON string.
+func Quote(src mem.RO) []byte {
+	buf := make([]byte, 0, src.Len())
+	putByte := func(bs ...byte) { buf = append(buf, bs...) }
+
+	i := 0
+	for i < src.Len() {
+		r, n := mem.DecodeRune(src)
+		if r < utf8.RuneSelf {
+			if r < ' ' {
+				if b := controlEsc[r]; b != 0 {
+					putByte('\\', b)
+				} else {
+					putByte('\\', 'u', '0', '0', hexDigit[int(r>>4)], hexDigit[int(r&15)])
+				}
+			} else if r == '\\' || r == '"' {
+				putByte('\\', byte(r))
+			} else {
+				putByte(byte(r))
+			}
+			src = src.SliceFrom(n)
+			continue
+		}
+
+		switch r {
+		case '\ufffd': // replacement rune
+			buf = append(buf, `\ufffd`...)
+		case '\u2028': // line separator
+			buf = append(buf, `\u2028`...)
+		case '\u2029': // paragraph separator
+			buf = append(buf, `\u2029`...)
+		default:
+			var rbuf [6]byte
+			n := utf8.EncodeRune(rbuf[:], r)
+			buf = append(buf, rbuf[:n]...)
+		}
+
+		src = src.SliceFrom(n)
+	}
+	return buf
+}

--- a/internal/escape/unquote.go
+++ b/internal/escape/unquote.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2023 Michael J. Fromberger. All Rights Reserved.
+
+package escape
+
+import (
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	"go4.org/mem"
+)
+
+// Unquote decodes a byte slice containing the JSON encoding of a string. The
+// input must have the enclosing double quotation marks already removed.
+//
+// Escape sequences are replaced with their unescaped equivalents. Invalid
+// escapes are replaced by the Unicode replacement rune. Unquote reports an
+// error for an incomplete escape sequence.
+func Unquote(src mem.RO) ([]byte, error) {
+	dec := make([]byte, 0, src.Len())
+	i := mem.IndexByte(src, '\\')
+	if i < 0 {
+		dec = mem.Append(dec, src)
+		return dec, nil
+	}
+
+	putByte := func(bs ...byte) { dec = append(dec, bs...) }
+	putRune := func(r rune) {
+		var buf [6]byte
+		n := utf8.EncodeRune(buf[:], r)
+		dec = append(dec, buf[:n]...)
+	}
+	for src.Len() != 0 {
+		dec = mem.Append(dec, src.SliceTo(i))
+
+		// Decode the next rune after the escape to figure out what to
+		// substitute. There should not be errors here, but if there are, insert
+		// replacement runes (utf8.RuneError == '\ufffd').
+		src = src.SliceFrom(i + 1)
+		if src.Len() == 0 {
+			return nil, errors.New("incomplete escape sequence")
+		}
+		r, n := mem.DecodeRune(src)
+		if n == 0 {
+			n++
+		}
+
+		src = src.SliceFrom(n)
+		switch r {
+		case '"', '\\', '/':
+			putByte(byte(r))
+		case 'b':
+			putByte('\b')
+		case 'f':
+			putByte('\f')
+		case 'n':
+			putByte('\n')
+		case 'r':
+			putByte('\r')
+		case 't':
+			putByte('\t')
+		case 'u':
+			if src.Len() < 4 {
+				return nil, errors.New("incomplete Unicode escape")
+			}
+			v, err := parseHex(src.SliceTo(4))
+			if err != nil {
+				putRune(utf8.RuneError)
+			} else {
+				putRune(rune(v))
+			}
+			src = src.SliceFrom(4)
+		default:
+			putRune(utf8.RuneError)
+		}
+
+		// Look for the next escape sequence, and if one is not found we can blit
+		// the rest of the input and go home.
+		i = mem.IndexByte(src, '\\')
+		if i < 0 {
+			dec = mem.Append(dec, src)
+			break
+		}
+	}
+	return dec, nil
+}
+
+func parseHex(data mem.RO) (int64, error) {
+	var v int64
+	for i := 0; i < data.Len(); i++ {
+		b := data.At(i)
+		v <<= 4
+		if '0' <= b && b <= '9' {
+			v += int64(b - '0')
+		} else if 'a' <= b && b <= 'f' {
+			v += int64(b - 'a' + 10)
+		} else if 'A' <= b && b <= 'F' {
+			v += int64(b - 'A' + 10)
+		} else {
+			return 0, fmt.Errorf("invalid hex digit %q", b)
+		}
+	}
+	return v, nil
+}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -118,15 +118,15 @@ func TestScanner_decodeAs(t *testing.T) {
 		if got := string(text); got != wantText {
 			t.Errorf("Text: got %#q, want %#q", got, wantText)
 		}
-		if u, err := jtree.Unescape(text[1 : len(text)-1]); err != nil {
-			t.Errorf("Unescape failed: %v", err)
+		if u, err := jtree.Unquote(text[1 : len(text)-1]); err != nil {
+			t.Errorf("Unquote failed: %v", err)
 		} else if got := string(u); got != wantDec {
-			t.Errorf("Unescape: got %#q, want %#q", got, wantDec)
+			t.Errorf("Unquote: got %#q, want %#q", got, wantDec)
 		}
 	})
 }
 
-func TestEscape(t *testing.T) {
+func TestQuote(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -142,7 +142,7 @@ func TestEscape(t *testing.T) {
 		{"<\x1e>", `<\u001e>`},
 	}
 	for _, test := range tests {
-		got := string(jtree.Escape(test.input))
+		got := string(jtree.Quote(test.input))
 		if got != test.want {
 			t.Errorf("Input: %#q\nGot:  %#q\nWant: %#q", test.input, got, test.want)
 		}

--- a/stream.go
+++ b/stream.go
@@ -37,7 +37,7 @@ type Handler interface {
 	EndArray(loc Anchor) error
 
 	// Begin a new object member, whose key is at loc. The handler is
-	// responsible for unescaping key values (see jtree.Unescape).
+	// responsible for unescaping key values (see jtree.Unquote).
 	BeginMember(loc Anchor) error
 
 	// End the current object member giving the location and type of the token


### PR DESCRIPTION
For many of the common operations in the scanner and parser, we can get rid of redundant byte-to-string copies by using the mem.RO type, which provides a view of the underlying data.

Move the internals of the Quote and Unquote functions to an internal package that uses the mem.RO type, and rework the exported versions as wrappers.

Benchmarks:

  name                       old time/op    new time/op    delta
  Scanner/JTree/Scanner-10     1.47ms ± 0%    1.41ms ± 0%   -3.89%
  Scanner/JTree/Stream-10      1.52ms ± 0%    1.46ms ± 0%   -4.39%
  Scanner/JTree/ParseAST-10    2.22ms ± 0%    2.17ms ± 0%   -2.35%

  name                       old alloc/op   new alloc/op   delta
  Scanner/JTree/Scanner-10     7.70kB ± 0%    4.69kB ± 0%  -39.09%
  Scanner/JTree/Stream-10      7.93kB ± 0%    4.82kB ± 0%  -39.15%
  Scanner/JTree/ParseAST-10     727kB ± 0%     723kB ± 0%   -0.43%

  name                       old allocs/op  new allocs/op  delta
  Scanner/JTree/Scanner-10        580 ± 0%         6 ± 0%  -98.97%
  Scanner/JTree/Stream-10         583 ± 0%         8 ± 0%  -98.63%
  Scanner/JTree/ParseAST-10     20.8k ± 0%     20.2k ± 0%   -2.77%