### PR TITLE
tq: rename the query package

### DIFF
--- a/tq/example_test.go
+++ b/tq/example_test.go
@@ -1,4 +1,4 @@
-package query_test
+package tq_test
 
 import (
 	"fmt"
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/creachadair/jtree/ast"
-	"github.com/creachadair/jtree/query"
+	"github.com/creachadair/jtree/tq"
 )
 
 func mustParseOne(s string) ast.Value {
@@ -21,7 +21,7 @@ func mustParseOne(s string) ast.Value {
 
 func Example_small() {
 	root := mustParseOne(`[{"a": 1, "b": 2}, {"c": {"d": true}, "e": false}]`)
-	v, err := query.Eval(root, query.Path(1, "c", "d"))
+	v, err := tq.Eval(root, tq.Path(1, "c", "d"))
 	if err != nil {
 		log.Fatalf("Eval: %v", err)
 	}
@@ -45,15 +45,15 @@ func Example_medium() {
   }
 }`)
 
-	v, err := query.Eval(root, query.Object{
-		"name": query.Path("plaintiff"),
-		"act": query.Array{
-			query.Path("complaint", "defendant"),
-			query.Path("complaint", "action"),
-			query.Value("my"),
-			query.Path("relatedPersons", "Individual 1", "id"),
+	v, err := tq.Eval(root, tq.Object{
+		"name": tq.Path("plaintiff"),
+		"act": tq.Array{
+			tq.Path("complaint", "defendant"),
+			tq.Path("complaint", "action"),
+			tq.Value("my"),
+			tq.Path("relatedPersons", "Individual 1", "id"),
 		},
-		"req": query.Path("requestedRelief", 0),
+		"req": tq.Path("requestedRelief", 0),
 	})
 	if err != nil {
 		log.Fatalf("Eval: %v", err)

--- a/tq/func.go
+++ b/tq/func.go
@@ -1,4 +1,4 @@
-package query
+package tq
 
 import "github.com/creachadair/jtree/ast"
 

--- a/tq/internal.go
+++ b/tq/internal.go
@@ -1,4 +1,4 @@
-package query
+package tq
 
 import (
 	"errors"

--- a/tq/tq.go
+++ b/tq/tq.go
@@ -1,4 +1,4 @@
-// Package query implements structural queries over JSON values.
+// Package tq implements structural traversal queries over JSON values.
 //
 // A query describes a syntactic substructure of a JSON syntax tree, such as an
 // object member, array element, or a path through the tree. Evaluating a query
@@ -13,10 +13,10 @@
 //
 // the query
 //
-//	query.Path(1, "c", "d")
+//	tq.Path(1, "c", "d")
 //
 // yields the value "true".
-package query
+package tq
 
 import (
 	"errors"


### PR DESCRIPTION
It's a little nicer if this package can have a shorter name, since it is repeated all over the place during query building.