### PR TITLE
tq: rework environments and binding

### DIFF
--- a/tq/func.go
+++ b/tq/func.go
@@ -11,22 +11,22 @@ func Is[T ast.Value]() Query { return Match[T](func(T) bool { return true }) }
 
 // IsNot returns its input if it does not have type T; otherwise it fails.
 func IsNot[T ast.Value]() Query {
-	return Func(func(_ Env, v ast.Value) (ast.Value, error) {
+	return Func(func(e Env, v ast.Value) (Env, ast.Value, error) {
 		if _, ok := v.(T); ok {
-			return nil, errors.New("value type does not match")
+			return e, nil, errors.New("value type does not match")
 		}
-		return v, nil
+		return e, v, nil
 	})
 }
 
 // Match returns its input if it has the specified type and f reports true for
 // its value. Otherwise, the query fails.
 func Match[T ast.Value](f func(T) bool) Query {
-	return Func(func(_ Env, v ast.Value) (ast.Value, error) {
+	return Func(func(e Env, v ast.Value) (Env, ast.Value, error) {
 		w, ok := v.(T)
 		if ok && f(w) {
-			return v, nil
+			return e, v, nil
 		}
-		return nil, errors.New("value does not match")
+		return e, nil, errors.New("value does not match")
 	})
 }

--- a/tq/internal.go
+++ b/tq/internal.go
@@ -3,6 +3,7 @@ package tq
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/creachadair/jtree/ast"
@@ -29,35 +30,35 @@ func pathElem(key any) Query {
 
 type objKey string
 
-func (o objKey) eval(_ *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Object](v, func(obj ast.Object) (ast.Value, error) {
+func (o objKey) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Object](qs, v, func(obj ast.Object) (*qstate, ast.Value, error) {
 		mem := obj.Find(string(o))
 		if mem == nil {
-			return nil, fmt.Errorf("key %q not found", o)
+			return qs, nil, fmt.Errorf("key %q not found", o)
 		}
-		return mem.Value, nil
+		return qs, mem.Value, nil
 	})
 }
 
 type nthQuery int
 
-func (nq nthQuery) eval(_ *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Array](v, func(a ast.Array) (ast.Value, error) {
+func (nq nthQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Array](qs, v, func(a ast.Array) (*qstate, ast.Value, error) {
 		idx := int(nq)
 		if idx < 0 {
 			idx += len(a)
 		}
 		if idx < 0 || idx >= len(a) {
-			return nil, fmt.Errorf("index %d out of range (0..%d)", nq, len(a))
+			return qs, nil, fmt.Errorf("index %d out of range (0..%d)", nq, len(a))
 		}
-		return a[idx], nil
+		return qs, a[idx], nil
 	})
 }
 
 type sliceQuery struct{ lo, hi int }
 
-func (q sliceQuery) eval(_ *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Array](v, func(arr ast.Array) (ast.Value, error) {
+func (q sliceQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Array](qs, v, func(arr ast.Array) (*qstate, ast.Value, error) {
 		lox := q.lo
 		if lox < 0 {
 			lox += len(arr)
@@ -67,72 +68,77 @@ func (q sliceQuery) eval(_ *qstate, v ast.Value) (ast.Value, error) {
 			hix += len(arr)
 		}
 		if lox < 0 || lox >= len(arr) {
-			return nil, fmt.Errorf("index %d out of range (0..%d)", q.lo, len(arr))
+			return qs, nil, fmt.Errorf("index %d out of range (0..%d)", q.lo, len(arr))
 		} else if hix < 0 || hix > len(arr) {
-			return nil, fmt.Errorf("index %d out of range (0..%d)", q.hi, len(arr))
+			return qs, nil, fmt.Errorf("index %d out of range (0..%d)", q.hi, len(arr))
 		} else if lox > hix {
-			return nil, fmt.Errorf("index start %d > end %d", q.lo, q.hi)
+			return qs, nil, fmt.Errorf("index start %d > end %d", q.lo, q.hi)
 		}
-		return arr[lox:hix], nil
+		return qs, arr[lox:hix], nil
 	})
 }
 
 type pickQuery []int
 
-func (q pickQuery) eval(_ *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Array](v, func(arr ast.Array) (ast.Value, error) {
+func (q pickQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Array](qs, v, func(arr ast.Array) (*qstate, ast.Value, error) {
 		var out ast.Array
 		for _, off := range q {
 			if off < 0 {
 				off += len(arr)
 			}
 			if off < 0 || off >= len(arr) {
-				return nil, fmt.Errorf("index %d out of range (0..%d)", off, len(arr))
+				return qs, nil, fmt.Errorf("index %d out of range (0..%d)", off, len(arr))
 			}
 			out = append(out, arr[off])
 		}
-		return out, nil
+		return qs, out, nil
 	})
 }
 
 type eachQuery struct{ Query }
 
-func (q eachQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Array](v, func(a ast.Array) (ast.Value, error) {
+func (q eachQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Array](qs, v, func(a ast.Array) (*qstate, ast.Value, error) {
 		var out ast.Array
 		for i, elt := range a {
-			v, err := q.Query.eval(qs, elt)
+			_, v, err := q.Query.eval(qs, elt)
 			if err != nil {
-				return nil, fmt.Errorf("index %d: %w", i, err)
+				return qs, nil, fmt.Errorf("index %d: %w", i, err)
 			}
 			out = append(out, v)
 		}
-		return out, nil
+		return qs, out, nil
 	})
 }
 
 type lenQuery struct{}
 
-func (lenQuery) eval(_ *qstate, v ast.Value) (ast.Value, error) {
+func (lenQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	if t, ok := v.(interface {
 		Len() int
 	}); ok {
-		return ast.Int(t.Len()), nil
+		return qs, ast.Int(t.Len()), nil
 	}
-	return nil, fmt.Errorf("cannot take length of %T", v)
+	return qs, nil, fmt.Errorf("cannot take length of %T", v)
 }
 
 type recQuery struct{ Query }
 
-func (q recQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
+func (q recQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	var out ast.Array
 
-	stk := []ast.Value{v}
+	type entry struct {
+		s *qstate
+		v ast.Value
+	}
+	stk := []entry{{qs, v}}
 	for len(stk) != 0 {
 		next := stk[len(stk)-1]
 		stk = stk[:len(stk)-1]
 
-		if r, err := q.Query.eval(qs, next); err == nil {
+		ns, r, err := q.Query.eval(next.s, next.v)
+		if err == nil {
 			if a, ok := r.(ast.Array); ok {
 				out = append(out, a...)
 			} else {
@@ -141,64 +147,61 @@ func (q recQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
 		}
 
 		// N.B. Push in reverse order, so we visit in lexical order.
-		switch t := next.(type) {
+		switch t := next.v.(type) {
 		case ast.Object:
 			for i := len(t) - 1; i >= 0; i-- {
-				stk = append(stk, t[i].Value)
+				stk = append(stk, entry{ns, t[i].Value})
 			}
 		case ast.Array:
 			for i := len(t) - 1; i >= 0; i-- {
-				stk = append(stk, t[i])
+				stk = append(stk, entry{ns, t[i]})
 			}
 		}
 	}
 
 	if len(out) == 0 {
-		return nil, errors.New("no matches")
+		return qs, nil, errors.New("no matches")
 	}
-	return out, nil
+	return qs, out, nil
 }
 
 type constQuery struct{ ast.Value }
 
-func (c constQuery) eval(*qstate, ast.Value) (ast.Value, error) { return c.Value, nil }
+func (c constQuery) eval(qs *qstate, _ ast.Value) (*qstate, ast.Value, error) {
+	return qs, c.Value, nil
+}
 
 type globQuery struct{}
 
-func (globQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
+func (globQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	switch t := v.(type) {
 	case ast.Object:
 		out := make(ast.Array, len(t))
 		for i, m := range t {
 			out[i] = m.Value
 		}
-		return out, nil
+		return qs, out, nil
 	case ast.Array:
-		return t, nil
+		return qs, t, nil
 	default:
-		return nil, errors.New("no matching values")
+		return qs, nil, errors.New("no matching values")
 	}
 }
 
 type keysQuery struct{}
 
-func (keysQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
+func (keysQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	var out ast.Array
 	if o, ok := v.(ast.Object); ok {
 		for _, m := range o {
 			out = append(out, m.Key)
 		}
-		return out, nil
+		return qs, out, nil
 	} else if v == ast.Null {
-		return out, nil
+		return qs, out, nil
 	}
 
-	return nil, fmt.Errorf("cannot list keys of %T", v)
-}
-
-type letQuery struct {
-	binds Let
-	next  Query
+	return qs, nil, fmt.Errorf("cannot list keys of %T", v)
 }
 
 func isMarked(s string) (string, bool) {
@@ -212,41 +215,34 @@ func isMarked(s string) (string, bool) {
 	return s, false
 }
 
-func (q letQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
-	ns := qs.push()
-	for _, b := range q.binds {
-		base, _ := isMarked(b.Name)
-		w, err := b.Query.eval(ns, v)
-		if err != nil {
-			return nil, fmt.Errorf("in %q: %w", base, err)
-		}
-		ns.bind(base, w)
-	}
-	return q.next.eval(ns, v)
-}
-
 type getQuery struct{ name string }
 
-func (q getQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
+func (q getQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	if w, ok := qs.lookup(q.name); ok {
-		return w, nil
+		return qs, w, nil
 	}
-	return nil, fmt.Errorf("parameter %q not found", q.name)
+	return qs, nil, fmt.Errorf("parameter %q not found", q.name)
 }
 
-type setQuery struct{ name string }
+type asQuery struct {
+	name string
+	q    Query
+}
 
-func (q setQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
-	qs.bind(q.name, v)
-	return v, nil
+func (q asQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	_, w, err := q.q.eval(qs, v)
+	if err != nil {
+		return qs, nil, err
+	}
+	return qs.bind(q.name, w), v, nil
 }
 
 type refQuery struct{ Query }
 
-func (r refQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
-	w, err := r.Query.eval(qs, v)
+func (r refQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	_, w, err := r.Query.eval(qs, v)
 	if err != nil {
-		return nil, err
+		return qs, nil, err
 	}
 	switch t := w.(type) {
 	case ast.Numeric:
@@ -254,63 +250,47 @@ func (r refQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
 	case ast.Keyer:
 		return objKey(t.Key()).eval(qs, v)
 	}
-	return nil, fmt.Errorf("value %T is not a valid reference", w)
+	log.Printf("MJF :: v=%[1]T %[1]v", v)
+	return qs, nil, fmt.Errorf("value %T is not a valid reference", w)
 }
 
 type selectQuery struct{ Query }
 
-func (q selectQuery) eval(qs *qstate, v ast.Value) (ast.Value, error) {
-	return with[ast.Array](v, func(a ast.Array) (ast.Value, error) {
+func (q selectQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
+	return with[ast.Array](qs, v, func(a ast.Array) (*qstate, ast.Value, error) {
 		var out ast.Array
 		for _, elt := range a {
-			if _, err := q.Query.eval(qs, elt); err == nil {
+			if _, _, err := q.Query.eval(qs, elt); err == nil {
 				out = append(out, elt)
 			}
 		}
-		return out, nil
+		return qs, out, nil
 	})
 }
 
-func with[T ast.Value](v ast.Value, f func(T) (ast.Value, error)) (ast.Value, error) {
+func with[T ast.Value](qs *qstate, v ast.Value, f func(T) (*qstate, ast.Value, error)) (*qstate, ast.Value, error) {
 	if v, ok := v.(T); ok {
 		return f(v)
 	}
 	var zero T
-	return nil, fmt.Errorf("got %T, want %T", v, zero)
+	return qs, nil, fmt.Errorf("got %T, want %T", v, zero)
 }
 
 type qstate struct {
-	bindings []binding
-	up       *qstate
-}
-
-type binding struct {
 	name  string
 	value ast.Value
+	up    *qstate
 }
 
 func (s *qstate) bind(name string, value ast.Value) *qstate {
-	for i, b := range s.bindings {
-		if b.name == name {
-			s.bindings[i].value = value
-			return s
-		}
-	}
-	s.bindings = append(s.bindings, binding{name: name, value: value})
-	return s
+	return &qstate{name: name, value: value, up: s}
 }
 
 func (s *qstate) lookup(name string) (ast.Value, bool) {
-	cur := s
-	for cur != nil {
-		for _, b := range cur.bindings {
-			if b.name == name {
-				return b.value, true
-			}
+	for cur := s; cur != nil; cur = cur.up {
+		if cur.name == name {
+			return cur.value, true
 		}
-		cur = cur.up
 	}
 	return nil, false
 }
-
-func (s *qstate) push() *qstate { return &qstate{up: s} }

--- a/tq/jpath_test.go
+++ b/tq/jpath_test.go
@@ -60,8 +60,8 @@ func TestJSONPathInputs(t *testing.T) {
 		},
 		{
 			"LastBook2", "$..book[(@.length-1)]",
-			tq.Recur("book", tq.Ref(tq.Func(func(e tq.Env, v ast.Value) (ast.Value, error) {
-				return ast.Int(v.(ast.Array).Len() - 1), nil
+			tq.Recur("book", tq.Ref(tq.Func(func(e tq.Env, v ast.Value) (tq.Env, ast.Value, error) {
+				return e, ast.Int(v.(ast.Array).Len() - 1), nil
 			}))),
 
 			`[{"category":"fiction","author":"J. R. R. Tolkien","title":"The Lord of the Rings","isbn":"0-395-19395-8","price":22.99}]`,

--- a/tq/tq.go
+++ b/tq/tq.go
@@ -205,8 +205,9 @@ func Keys() Query { return keysQuery{} }
 // the specified parameter name. The query fails if the name is not defined.
 func Get(name string) Query { base, _ := isMarked(name); return getQuery{base} }
 
-// As evaluates the given path on its input, then returns its input in an
-// environment where name is bound to the result from that path.
+// As evaluates the given subquery on its input, then returns its input in an
+// environment where name is bound to the result from the subquery. If the
+// subquery is empty, the name is bound to the input itself.
 func As(name string, keys ...any) Query {
 	base, _ := isMarked(name)
 	return asQuery{base, Path(keys...)}


### PR DESCRIPTION
The handling of bindings was asymmetric and confusing. The Get and Set queries
would mutate the environment in-place, while Let would bind names in scope.
Let was also clunky to write, and the "nice" way of using it with inline
bindings triggers lint warnings because of the unkeyed initializers.

Summary:

- extend the Query interface to return a new environment.
- each environment now contains (only) one binding.
- remove the Let and Set constructs.
- add As to do bindings.
- rework Func to return environments too.
