### PR TITLE
Add package jwcc implementing a parser for JWCC documents.

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ['stable', 'oldstable']
+        go-version: ['stable']
         os: ['ubuntu-latest']
     steps:
     - uses: actions/checkout@v3

--- a/ast/jwcc/ast.go
+++ b/ast/jwcc/ast.go
@@ -1,0 +1,141 @@
+package jwcc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/creachadair/jtree"
+	"github.com/creachadair/jtree/ast"
+)
+
+// An Array is a commented array of values.
+type Array struct {
+	Values []Value
+
+	com Comments
+}
+
+func (a *Array) Comments() *Comments { return &a.com }
+
+func (a Array) JSON() string {
+	if len(a.Values) == 0 {
+		return "[]"
+	}
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(a.Values[0].JSON())
+	for _, elt := range a.Values[1:] {
+		sb.WriteByte(',')
+		sb.WriteString(elt.JSON())
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+func (a Array) String() string { return fmt.Sprintf("Array(len=%d)", len(a.Values)) }
+
+// A Datum is a commented base value; a string, number, Boolean, or null.
+type Datum struct {
+	ast.Value
+
+	com Comments
+}
+
+func (d *Datum) Comments() *Comments { return &d.com }
+
+// A Document is a single value with optional trailing comments.
+type Document struct {
+	Value
+
+	com Comments
+}
+
+func (d *Document) Comments() *Comments { return &d.com }
+
+// A Member is a key-value pair in an object.
+type Member struct {
+	Key   ast.Keyer
+	Value Value
+
+	com Comments
+}
+
+func (m *Member) Comments() *Comments { return &m.com }
+
+func (m Member) JSON() string {
+	k := jtree.Quote(m.Key.Key())
+	v := m.Value.JSON()
+	buf := make([]byte, len(k)+len(v)+1)
+	n := copy(buf, k)
+	buf[n] = ':'
+	copy(buf[n+1:], v)
+	return string(buf)
+}
+
+func (m Member) String() string { return fmt.Sprintf("Member(key=%q)", m.Key) }
+
+// An Object is a collection of key-value members.
+type Object struct {
+	Members []*Member
+
+	com Comments
+}
+
+func (o *Object) Comments() *Comments { return &o.com }
+
+func (o *Object) Find(key string) *Member {
+	for _, m := range o.Members {
+		if m.Key.Key() == key {
+			return m
+		}
+	}
+	return nil
+}
+
+func (o Object) Len() int { return len(o.Members) }
+
+func (o Object) JSON() string {
+	if len(o.Members) == 0 {
+		return "{}"
+	}
+	var sb strings.Builder
+	sb.WriteByte('{')
+	sb.WriteString(o.Members[0].JSON())
+	for _, elt := range o.Members[1:] {
+		sb.WriteByte(',')
+		sb.WriteString(elt.JSON())
+	}
+	sb.WriteByte('}')
+	return sb.String()
+}
+
+func (o Object) String() string { return fmt.Sprintf("Object(len=%d)", len(o.Members)) }
+
+// commentStub is a stack placeholder for a comment seen during parsing.
+// This type does not appear in a completed AST.
+type commentStub struct {
+	ast.Value
+
+	text string
+	span jtree.Span
+}
+
+func (commentStub) Comments() *Comments { return nil }
+
+// arrayStub is a stack placeholder for an incomplete array during parsing.
+// This type does not appear in a completed AST.
+type arrayStub struct {
+	ast.Value
+	com Comments
+}
+
+func (a *arrayStub) Comments() *Comments { return &a.com }
+
+// objectStub is a stack placeholder for an incomplete object during parsing.
+// This type does not appear in a completed AST.
+type objectStub struct {
+	ast.Value
+	com Comments
+}
+
+func (o *objectStub) Comments() *Comments { return &o.com }

--- a/ast/jwcc/jwcc.go
+++ b/ast/jwcc/jwcc.go
@@ -1,0 +1,257 @@
+// Package jwcc implements a parser for JSON With Commas and Comments (JWCC) as
+// defined by https://nigeltao.github.io/blog/2021/json-with-commas-comments.html
+package jwcc
+
+import (
+	"errors"
+	"io"
+
+	"github.com/creachadair/jtree"
+	"github.com/creachadair/jtree/ast"
+	"golang.org/x/exp/slices"
+)
+
+// A Value is a JSON value optionally decorated with comments.
+type Value interface {
+	ast.Value
+
+	// Comments returns the comments annotating this value.
+	Comments() *Comments
+}
+
+// Comments records the comments associated with a value.
+type Comments struct {
+	Before []string
+	Line   string
+	End    []string
+
+	eline int
+}
+
+// IsEmpty reports whether c is "empty", meaning it has no non-empty comment
+// text for its associated value.
+func (c Comments) IsEmpty() bool {
+	return len(c.Before) == 0 && c.Line == "" && len(c.End) == 0
+}
+
+// Parse parses and returns a single JWCC value from r.  If r contains data
+// after the first value, apart from comments and whitespace, Parse returns the
+// first value along with an ast.ErrExtraInput error.
+func Parse(r io.Reader) (*Document, error) {
+	st := jtree.NewStream(r)
+	st.AllowComments(true)
+	st.AllowTrailingCommas(true)
+
+	h := &parseHandler{ic: make(jtree.Interner)}
+	if err := st.ParseOne(h); err != nil {
+		return nil, err
+	} else if len(h.stk) != 1 {
+		return nil, errors.New("incomplete value")
+	}
+	v := h.stk[0]
+	d := &Document{Value: v}
+	h.stk[0] = d
+	if !h.eof {
+		err := st.ParseOne(h)
+		d.Comments().End = h.consumeComments()
+		if err != nil && !errors.Is(err, io.EOF) {
+			return d, errors.Join(ast.ErrExtraInput, err)
+		}
+	}
+	return d, nil
+}
+
+// parseHandler implements the jtree.Handler interface for JWCC values.
+type parseHandler struct {
+	stk []Value
+	ic  jtree.Interner
+	eof bool
+}
+
+func (h *parseHandler) BeginObject(loc jtree.Anchor) error {
+	h.pushValue(loc, &objectStub{})
+	return nil
+}
+
+func (h *parseHandler) EndObject(loc jtree.Anchor) error {
+	com := h.consumeComments() // trailing comments at the end of the object
+	for i := len(h.stk) - 1; i >= 0; i-- {
+		if stub, ok := h.stk[i].(*objectStub); ok {
+			stub.Comments().End = com
+
+			ms := make([]*Member, 0, len(h.stk)-i-1)
+			for j := i + 1; j < len(h.stk); j++ {
+				ms = append(ms, h.stk[j].(*Member))
+			}
+			h.stk = h.stk[:i+1]
+			h.stk[i] = &Object{
+				Members: ms,
+				com:     *stub.Comments(),
+			}
+			return nil
+		}
+	}
+	panic("unbalanced EndObject")
+}
+
+func (h *parseHandler) BeginArray(loc jtree.Anchor) error {
+	h.pushValue(loc, &arrayStub{})
+	return nil
+}
+
+func (h *parseHandler) EndArray(loc jtree.Anchor) error {
+	com := h.consumeComments()
+	for i := len(h.stk) - 1; i >= 0; i-- {
+		if stub, ok := h.stk[i].(*arrayStub); ok {
+			stub.Comments().End = com
+
+			vals := make([]Value, len(h.stk)-i-1)
+			copy(vals, h.stk[i+1:])
+			h.stk = h.stk[:i+1]
+
+			h.stk[i] = &Array{
+				Values: vals,
+				com:    *stub.Comments(),
+			}
+			return nil
+		}
+	}
+	panic("unbalanced EndArray")
+}
+
+func (h *parseHandler) BeginMember(loc jtree.Anchor) error {
+	// Note: Comments between the key and the colon are offset to above the key.
+	h.pushValue(loc, &Member{
+		Key: ast.NewQuoted(h.ic.Intern(loc.Text())),
+	})
+	return nil
+}
+
+func (h *parseHandler) EndMember(loc jtree.Anchor) error {
+	com := h.consumeComments()
+	n := len(h.stk)
+	m := h.stk[n-2].(*Member)
+	m.Comments().End = com
+	m.Comments().eline = loc.Location().Last.Line
+	m.Value = h.stk[n-1]
+	h.stk = h.stk[:n-1]
+	return nil
+}
+
+func (h *parseHandler) Value(loc jtree.Anchor) error {
+	v, err := ast.AnchorValue(loc)
+	if err != nil {
+		return err
+	}
+	h.pushValue(loc, &Datum{Value: v})
+	return nil
+}
+
+func (h *parseHandler) EndOfInput(loc jtree.Anchor) { h.eof = true }
+
+func (h *parseHandler) Comment(loc jtree.Anchor) { h.pushComment(loc) }
+
+/*
+  Attachment rules for comments:
+
+  Each token and grammar phrase is identified by its source span.
+
+  The BEFORE comments of a phrase are all those ending before the start of its
+  span and starting after the end of the previous token.
+
+  The LINE comment of a phrase is a line-ending ("//") comment starting on the
+  same line as the end of the phrase.
+
+  The END comments of a phrase are comments that occur at the end of the phrase
+  that were not claimed by any other substructure of the phrase. This applies
+  to arrays, objects, and object members.
+
+  When the parser encounters a comment token:
+
+  - If the top of the stack is a complete grammar phrase (not a comment, not an
+    object or array stub) and the new token is a line comment on the same line
+    a the end of that phrase, the new token is attached to the phrase as its
+    line comment.
+
+  - Otherwise, the comment is shifted.
+
+  When a non-comment token is shifted:
+
+  - The parser pops off all the comments atop the stack and joins them into a
+    group.
+
+  - If a grammar phrase remains atop the stack, and that phrase is not a
+    complete array or object, the parser records that this group is AFTER that
+    phrase.
+
+  - It records that the group is BEFORE the phrase beginning with the token
+    being shifted.
+
+  The subtleties about array and object phrases is to deal with comments that
+  occur alone at the end of an object or array body. When rendering, the AFTER
+  comments of an array should be rendered inside the value, before its closing
+  brace.
+
+  Similarly, we want a line comment after the END of the array or object to be
+  its line comment, not one just inside its opening brace.
+*/
+
+// consumeComments removes all comments from the top of the stack to form a
+// group. It returns nil if no comments were found atop the stack.
+func (h *parseHandler) consumeComments() []string {
+	var grp []string
+
+	i := len(h.stk) - 1
+	for i >= 0 {
+		c, ok := h.stk[i].(commentStub)
+		if !ok {
+			break
+		}
+		grp = append(grp, c.text)
+		i--
+	}
+	if len(grp) == 0 {
+		return nil // no comments found
+	}
+
+	h.stk = h.stk[:i+1] // pop
+	slices.Reverse(grp)
+	return grp
+}
+
+// pushComment handles a comment token by either adjoining it to the grammar
+// phrase atop the stack as its line comment, or shifting it.
+func (h *parseHandler) pushComment(loc jtree.Anchor) {
+	if i := len(h.stk) - 1; i >= 0 && loc.Token() == jtree.LineComment {
+		switch h.stk[i].(type) {
+		case *arrayStub, *objectStub:
+			// skip; we don't attach line comments to these
+		case commentStub:
+			// not a commentable value
+		default:
+			if t, ok := h.stk[i].(*Member); !ok || t.Value != nil {
+				c := h.stk[i].Comments()
+				if c.eline == loc.Location().First.Line { // same line
+					// Attach this as the line comment of the phrase.
+					c.Line = string(loc.Text())
+					return
+				}
+			}
+		}
+	}
+	h.stk = append(h.stk, commentStub{
+		text: string(loc.Text()),
+		span: loc.Location().Span,
+	})
+}
+
+// pushValue pushes v atop the stack after handling any pending comments.
+func (h *parseHandler) pushValue(loc jtree.Anchor, v Value) {
+	com := h.consumeComments() // do this first, it may update the stack
+	c := v.Comments()
+	c.Before = com
+	c.eline = loc.Location().Last.Line
+
+	// Otherwise, accumulate the value normally.
+	h.stk = append(h.stk, v)
+}

--- a/ast/jwcc/jwcc_test.go
+++ b/ast/jwcc/jwcc_test.go
@@ -1,0 +1,73 @@
+package jwcc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestBasic(t *testing.T) {
+	input := strings.NewReader(`// This is a JWCC document
+{
+  // Hello, I am an object member.
+  "name": ["value"], // and a trailing comment
+  "list": [
+     // whatever else you may think
+     // this is pretty cool
+     true,
+     false,
+     null,
+   ],  // is it me or is this stinky
+
+   "num": /* stuff */ 12.5 /* nonsense */,
+
+   "horse":
+       "pucky" // shenanigans
+  , // rumpus
+   // stuff at the end
+}
+/*
+  Various additional nonsense following the main document
+  which will get bunged on after.
+*/
+
+`)
+	d, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	t.Log(input)
+	walk(t, d, "")
+	t.Log(d.JSON())
+}
+
+func walk(t *testing.T, v Value, p string) {
+	t.Logf("%s%T", p, v)
+	c := v.Comments()
+	if len(c.Before) != 0 {
+		t.Logf("%s- before\n%s", p, strings.Join(c.Before, "\n"))
+	}
+	if c.Line != "" {
+		t.Logf("%s- line: %s", p, c.Line)
+	}
+	if len(c.End) != 0 {
+		t.Logf("%s- end\n%s", p, strings.Join(c.End, "\n"))
+	}
+	switch q := v.(type) {
+	case *Array:
+		for i, elt := range q.Values {
+			walk(t, elt, fmt.Sprintf("  %s[%d] ", p, i))
+		}
+	case *Member:
+		t.Logf("%s key=%q", p, q.Key)
+		walk(t, q.Value, p+"  ")
+	case *Object:
+		for _, elt := range q.Members {
+			walk(t, elt, p+"  ")
+		}
+	case *Datum:
+		t.Logf("%s datum=%v", p, q.JSON())
+	case *Document:
+		walk(t, q.Value, p+"  ")
+	}
+}

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -147,8 +147,9 @@ func (h *parseHandler) EndArray(loc jtree.Anchor) error {
 }
 
 func (h *parseHandler) BeginMember(loc jtree.Anchor) error {
-	key := Quoted{data: mem.S(h.ic.Intern(loc.Text()))}
-	h.push(&Member{Key: key})
+	h.push(&Member{
+		Key: Quoted{data: mem.S(h.ic.Intern(loc.Text()))},
+	})
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/creachadair/jtree
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13
 )
 
-require github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
+require (
+	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
+	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
+)

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29X
 github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 go4.org/mem v0.0.0-20220726221520-4f986261bf13 h1:CbZeCBZ0aZj8EfVgnqQcYZgf0lpZ3H9rmp5nkDTAst8=
 go4.org/mem v0.0.0-20220726221520-4f986261bf13/go.mod h1:reUoABIJ9ikfM5sgtSF3Wushcza7+WeD01VB9Lirh3g=
+golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691 h1:/yRP+0AN7mf5DkD3BAI6TOFnd51gEoDEb8o35jIFtgw=
+golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=


### PR DESCRIPTION
This is a first pass at supporting a decorated AST for JWCC documents.
