### PR TITLE
jwcc: add helpers and docs for cleaning up comment text

### DIFF
--- a/jwcc/jwcc.go
+++ b/jwcc/jwcc.go
@@ -28,6 +28,14 @@ type Value interface {
 // Comments records the comments associated with a value.
 // All values have a comment record; use IsEmpty to test whether the value has
 // any actual comment text.
+//
+// Comments read during parsing are stored as-seen in the input, including
+// comment markers.  When adding or editing a comment programmatically, comment
+// markers are optional; the text will be decorated when formatting the output.
+//
+// If a comment begins with "//", it will be processed as line comments.
+// If a comment begins with "/*" it will be processed as a block comment.
+// Multiple lines are OK; they will be reformatted as necessary.
 type Comments struct {
 	Before []string
 	Line   string

--- a/jwcc/testdata/basic.jwcc
+++ b/jwcc/testdata/basic.jwcc
@@ -1,0 +1,44 @@
+
+// This is a JWCC document
+// everyone loves those
+
+{  // Hello, I am an object member.
+  "name": ["value",
+"village",
+], // and a trailing comment
+ "list": [     // whatever else you may think
+     // this is pretty cool
+    true, // a
+  false, // b
+   null, // c
+ {"pea":"brain", /*fool*/
+},
+
+        /*    I am a block comment
+          inside which
+             some stuff is special
+          and some is not.
+            */
+      
+
+  "soup" // nuts
+ ],  // is it me or is this stinky
+// hey all
+ "num":
+ /* stuff */ 12.5 /* nonsense */,
+"p":"q",
+
+   "f": {"zuul":true,
+   }, // the cat
+   //"x": 3,
+
+   "horse":
+       "pucky" // shenanigans
+  , // rumpus
+   // stuff at the end
+}/* Various additional nonsense following the main document
+  which will get bunged on after.*/
+
+
+
+

--- a/jwcc/utils.go
+++ b/jwcc/utils.go
@@ -4,6 +4,7 @@ package jwcc
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Path traverses a sequential path through the structure of a value starting
@@ -72,4 +73,20 @@ func fixArrayBound(n, i int) (int, bool) {
 		i += n
 	}
 	return i, i >= 0 && i < n
+}
+
+// CleanComments combines and removes comment markers from the given comments,
+// returning a slice of plain lines of text. Leading and trailing spaces are
+// removed from the lines.
+func CleanComments(coms ...string) []string {
+	var out []string
+	for _, com := range coms {
+		_, text := classifyComment(com)
+		lines := strings.Split(text, "\n")
+		outdentCommentLines(lines)
+		for _, line := range lines {
+			out = append(out, strings.TrimSpace(line))
+		}
+	}
+	return out
 }


### PR DESCRIPTION
- Document the programmatic use of Comments.
- Add a CleanComments helper.
- Move test data around to be a little nicer.
