### PR TITLE
ast: simplify the representation of strings

### DIFF
--- a/ast/cursor/cursor_test.go
+++ b/ast/cursor/cursor_test.go
@@ -78,7 +78,7 @@ func TestCursor(t *testing.T) {
 			true,
 		},
 	}
-	opt := cmp.AllowUnexported(ast.Quoted{}, testutil.RawNumberType)
+	opt := cmp.AllowUnexported(ast.String("").Quote(), testutil.RawNumberType)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := cursor.New(v).Down(tc.path...)

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -147,9 +147,7 @@ func (h *parseHandler) EndArray(loc jtree.Anchor) error {
 }
 
 func (h *parseHandler) BeginMember(loc jtree.Anchor) error {
-	h.push(&Member{
-		Key: Quoted{data: mem.S(h.ic.Intern(loc.Text()))},
-	})
+	h.push(&Member{Key: Quoted(h.ic.Intern(loc.Text()))})
 	return nil
 }
 
@@ -169,7 +167,7 @@ func (h *parseHandler) Value(loc jtree.Anchor) error {
 func AnchorValue(loc jtree.Anchor) (Value, error) {
 	switch loc.Token() {
 	case jtree.String:
-		return Quoted{data: mem.B(loc.Copy())}, nil
+		return quotedText{data: mem.B(loc.Copy())}, nil
 	case jtree.Integer:
 		return rawNumber{text: loc.Copy(), isInt: true}, nil
 	case jtree.Number:

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -23,9 +23,9 @@ var (
 
 type testValue int
 
-func (t testValue) JSON() string   { return strconv.Itoa(int(t)) }
-func (t testValue) String() string { return fmt.Sprintf("z=%d", t) }
-func (t testValue) Key() string    { return fmt.Sprintf("key=%d", t) }
+func (t testValue) JSON() string    { return strconv.Itoa(int(t)) }
+func (t testValue) String() string  { return fmt.Sprintf("z=%d", t) }
+func (t testValue) Quote() ast.Text { return ast.String(fmt.Sprintf("key=%d", t)).Quote() }
 
 func TestParse_JWCC(t *testing.T) {
 	input, err := os.ReadFile("../testdata/input.jwcc")
@@ -100,8 +100,8 @@ func TestParse(t *testing.T) {
 	if !ok {
 		t.Fatalf("Array entry is %T, not object", lst[0])
 	}
-	check[ast.Quoted](t, obj, "summary", func(s ast.Quoted) {
-		t.Logf("String field value: %s", s.Unquote())
+	check[ast.Text](t, obj, "summary", func(s ast.Text) {
+		t.Logf("String field value: %s", s.String())
 	})
 	check[ast.Number](t, obj, "episode", func(v ast.Number) {
 		t.Logf("Number field value: %v", v)

--- a/jwcc/ast.go
+++ b/jwcc/ast.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/creachadair/jtree"
 	"github.com/creachadair/jtree/ast"
 )
 
@@ -70,7 +69,7 @@ func (d *Document) Undecorate() ast.Value { return d.Value.Undecorate() }
 
 // A Member is a key-value pair in an object.
 type Member struct {
-	Key   ast.Keyer
+	Key   ast.Text
 	Value Value
 
 	com Comments
@@ -83,7 +82,7 @@ func (m *Member) Undecorate() ast.Value {
 }
 
 func (m Member) JSON() string {
-	k := jtree.Quote(m.Key.Key())
+	k := m.Key.Quote().JSON()
 	v := m.Value.JSON()
 	buf := make([]byte, len(k)+len(v)+1)
 	n := copy(buf, k)
@@ -119,7 +118,7 @@ func (o *Object) Undecorate() ast.Value {
 
 func (o *Object) Find(key string) *Member {
 	for _, m := range o.Members {
-		if m.Key.Key() == key {
+		if m.Key.String() == key {
 			return m
 		}
 	}

--- a/jwcc/cursor/cursor_test.go
+++ b/jwcc/cursor/cursor_test.go
@@ -60,7 +60,7 @@ func TestCursor(t *testing.T) {
 		},
 	}
 	opt := cmp.AllowUnexported(
-		ast.Quoted{},
+		ast.String("").Quote(),
 		testutil.RawNumberType,
 		jwcc.Array{},
 		jwcc.Comments{},

--- a/jwcc/jwcc.go
+++ b/jwcc/jwcc.go
@@ -142,9 +142,7 @@ func (h *parseHandler) BeginMember(loc jtree.Anchor) error {
 	// comments that occurred in the input before the colon separator.
 	// We move them all above the key when recording.
 
-	h.pushValue(loc, &Member{
-		Key: ast.NewQuoted(h.ic.Intern(loc.Text())),
-	})
+	h.pushValue(loc, &Member{Key: ast.Quoted(h.ic.Intern(loc.Text()))})
 	return nil
 }
 

--- a/tq/internal.go
+++ b/tq/internal.go
@@ -304,8 +304,8 @@ func (r refQuery) eval(qs *qstate, v ast.Value) (*qstate, ast.Value, error) {
 	switch t := w.(type) {
 	case ast.Number:
 		return nthQuery(int(t.Int())).eval(qs, v)
-	case ast.Keyer:
-		return objKey(t.Key()).eval(qs, v)
+	case ast.Text:
+		return objKey(t.String()).eval(qs, v)
 	}
 	return qs, nil, fmt.Errorf("value %T is not a valid reference", w)
 }


### PR DESCRIPTION
- Replace the Keyer interface with a Text interface.
- Unexport the Quoted string type, keeping only a constructor.
- Get rid of redundant methods; use String for all unquoted values.
