### PR TITLE
scanner: fix a corner case when lexing block comments

### DIFF
--- a/jwcc/testdata/basic.jwcc
+++ b/jwcc/testdata/basic.jwcc
@@ -20,7 +20,7 @@
           and some is not.
             */
       
-
+  /***/ // make sure that is self-contained
   "soup" // nuts
  ],  // is it me or is this stinky
 // hey all

--- a/scanner.go
+++ b/scanner.go
@@ -348,8 +348,8 @@ func (s *Scanner) scanComment(first rune) error {
 			if err != nil {
 				return err
 			}
-			s.buf.WriteRune(next)
 			if next == '/' {
+				s.buf.WriteRune(next)
 				s.tok = BlockComment
 				return nil
 			} else if next == '\n' {
@@ -358,6 +358,8 @@ func (s *Scanner) scanComment(first rune) error {
 			}
 
 			// We saw "*" but not "/", so keep scanning for the end of the block.
+			// Unread the rune so we will accumulate it on the next pass.
+			s.unrune()
 		}
 
 	default:


### PR DESCRIPTION
When seeing the block comment `/***/`, the scanner looks after the opening `/*` for
the end of the comment. Upon reaching a "*", it checks whether the next thing
is "/" which would end the comment.

If not, it resumes searching, but previously (in that case) the failing rune
was accumulated into the token. In this example, that means it has now consumed
the second star, which means the reader incorrectly treats the following "/" as
part of the comment body.

Instead, we need to unread the failing rune so that it gets picked up by the
next search pass. Do this, and update the tests to backstop it.
