### PR TITLE
scanner: make Next report a bool instead of an error

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -100,13 +100,11 @@ func BenchmarkScanner(b *testing.B) {
 		b.Run("Scanner", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				dec := jtree.NewScanner(bytes.NewReader(input))
-				for {
-					err := dec.Next()
-					if err == io.EOF {
-						break
-					} else if err != nil {
-						b.Fatalf("Unexpected error: %v", err)
-					}
+				for dec.Next() {
+					// nothing
+				}
+				if err := dec.Err(); err != nil {
+					b.Fatalf("Unexpected error: %v", err)
 				}
 			}
 		})

--- a/doc.go
+++ b/doc.go
@@ -9,14 +9,15 @@
 // advances to the next input token and returns nil, or reports an error:
 //
 //	s := jtree.NewScanner(input)
-//	for s.Next() == nil {
+//	for s.Next() {
 //	   log.Printf("Next token: %v", s.Token())
 //	}
 //
-// Next returns io.EOF when the input has been fully consumed. Any other error
-// indicates an I/O or lexical error in the input.
+// Next returns false if no further tokens are available. Use [Scanner.Err] to
+// discover the reason why. At the end of the input, [Scanner.Err] returns nil;
+// otherwise it indicates an I/O or lexical error.
 //
-//	if s.Err() != io.EOF {
+//	if s.Err() != nil {
 //	   log.Fatalf("Scanning failed: %v", err)
 //	}
 //

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -3,7 +3,6 @@
 package jtree_test
 
 import (
-	"io"
 	"strings"
 	"testing"
 
@@ -66,10 +65,10 @@ func TestScanner(t *testing.T) {
 	for _, test := range tests {
 		var got []jtree.Token
 		s := jtree.NewScanner(strings.NewReader(test.input))
-		for s.Next() == nil {
+		for s.Next() {
 			got = append(got, s.Token())
 		}
-		if s.Err() != io.EOF {
+		if s.Err() != nil {
 			t.Errorf("Next failed: %v", s.Err())
 		}
 		if diff := cmp.Diff(test.want, got); diff != "" {
@@ -133,13 +132,13 @@ false /*
 		var coms []string
 		s := jtree.NewScanner(strings.NewReader(test.input))
 		s.AllowComments(true)
-		for s.Next() == nil {
+		for s.Next() {
 			got = append(got, s.Token())
 			if tok := s.Token(); tok == jtree.LineComment || tok == jtree.BlockComment {
 				coms = append(coms, string(s.Text()))
 			}
 		}
-		if s.Err() != io.EOF {
+		if s.Err() != nil {
 			t.Errorf("Next failed: %v", s.Err())
 		}
 		if diff := cmp.Diff(test.want, got); diff != "" {
@@ -155,7 +154,7 @@ func TestScanner_decodeAs(t *testing.T) {
 	mustScan := func(t *testing.T, input string, want jtree.Token) *jtree.Scanner {
 		t.Helper()
 		s := jtree.NewScanner(strings.NewReader(input))
-		if s.Next() != nil {
+		if !s.Next() {
 			t.Fatalf("Next failed: %v", s.Err())
 		} else if s.Token() != want {
 			t.Fatalf("Next token: got %v, want %v", s.Token(), want)
@@ -238,10 +237,10 @@ func TestScannerLoc(t *testing.T) {
 		var got []tokPos
 		s := jtree.NewScanner(strings.NewReader(tc.input))
 		s.AllowComments(true)
-		for s.Next() == nil {
+		for s.Next() {
 			got = append(got, tokPos{s.Token(), s.Location().String()})
 		}
-		if s.Err() != io.EOF {
+		if s.Err() != nil {
 			t.Errorf("Next failed: %v", s.Err())
 		}
 		if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/stream.go
+++ b/stream.go
@@ -3,6 +3,7 @@
 package jtree
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"strings"
@@ -218,11 +219,7 @@ func (s *Stream) parseElements(h Handler) {
 }
 
 func (s *Stream) nextToken(h Handler) error {
-	for {
-		if err := s.s.Next(); err != nil {
-			return err
-		}
-
+	for s.s.Next() {
 		// If we see a comment token, pass it to the handler if it implements
 		// CommentHandler. Either way, discard the comment and fetch the next
 		// available comment for the rest of the parser.
@@ -234,6 +231,7 @@ func (s *Stream) nextToken(h Handler) error {
 		}
 		return nil
 	}
+	return cmp.Or(s.s.Err(), io.EOF)
 }
 
 func (s *Stream) advance(h Handler, tokens ...Token) Token {


### PR DESCRIPTION
In practical use, the caller is going to call Err to check the error anyway, so
there is no point in having Next report it too. To simplify the use of Next in
a simple loop, make it report bool instead.

Moreover, update Err to return nil at EOF instead of io.EOF explicitly. This
removes the need for the caller to check for that case manually.
