### PR TITLE
jwcc: add Formatter options for inline array formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/creachadair/mds v0.29.2
+	github.com/creachadair/mds v0.30.0
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/creachadair/mds v0.29.2 h1:1IBhfyolZUCA53twI1hXembOdpIe4bJ4OGJELBbGrN4=
-github.com/creachadair/mds v0.29.2/go.mod h1:dMBTCSy3iS3dwh4Rb1zxeZz2d7K8+N24GCTsayWtQRI=
+github.com/creachadair/mds v0.30.0 h1:TcrB0BMqSeDVTYaj8KpxXY5TQLr2G6bFvCIBfvMxBMI=
+github.com/creachadair/mds v0.30.0/go.mod h1:dMBTCSy3iS3dwh4Rb1zxeZz2d7K8+N24GCTsayWtQRI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=

--- a/jwcc/indent.go
+++ b/jwcc/indent.go
@@ -4,19 +4,47 @@ package jwcc
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"io"
+	"slices"
+	"strconv"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/creachadair/jtree/ast"
+	"github.com/creachadair/mds/value"
 )
 
 // A Formatter carries the settings for pretty-printing JWCC values.
 // A zero value is ready for use with default settings.
-type Formatter struct{}
+type Formatter struct {
+	// If positive, the maximum number of array elements that may be rendered on
+	// a single line. If this is zero or negative and MaxInlineArrayLength is
+	// positive, there is no fixed limit; otherwise the default limit is 3.
+	MaxInlineArrayElements int
 
-func (f Formatter) indent() string { return "  " }
+	// If positive, the maximum length of a single line containing inline array
+	// elements. If this is zero or negative, there is no fixed limit.
+	MaxInlineArrayLength int
 
-func (f Formatter) maxLineItems() int { return 3 }
+	// If non-empty, the string used as the increment of indentation.
+	// If empty, the default is "\x20\x20", that is, two ASCII spaces.
+	Indent string
+}
+
+func (f Formatter) indent() string { return cmp.Or(f.Indent, "  ") }
+
+func (f Formatter) maxInlineArrayElements() int {
+	if n := f.MaxInlineArrayElements; n > 0 {
+		return n
+	} else if f.MaxInlineArrayLength > 0 {
+		return 0 // means: no limit
+	}
+	return 3
+}
+
+func (f Formatter) maxInlineArrayLength() int { return f.MaxInlineArrayLength }
 
 // Format renders a pretty-printed representation of v to w with default
 // settings.
@@ -75,7 +103,7 @@ func (f Formatter) formatValue(w writeFlusher, v Value, init, indent string, lin
 }
 
 func (f Formatter) formatArray(w writeFlusher, a *Array, init, indent string) bool {
-	if f.isBoring(a) {
+	if f.isBoring(a, len(init)) {
 		fmt.Fprint(w, init, "[")
 		for i, v := range a.Values {
 			if i > 0 {
@@ -115,7 +143,7 @@ func (f Formatter) formatArray(w writeFlusher, a *Array, init, indent string) bo
 }
 
 func (f Formatter) formatObject(w writeFlusher, o *Object, init, indent string) bool {
-	if f.isBoring(o) {
+	if f.isBoring(o, len(init)) {
 		fmt.Fprint(w, init, "{")
 		for i, m := range o.Members {
 			if i > 0 {
@@ -136,14 +164,14 @@ func (f Formatter) formatObject(w writeFlusher, o *Object, init, indent string) 
 	for i, m := range o.Members {
 		// Leave extra space before the next member if either it or its
 		// predecessor was non-boring.
-		prevBoring, curBoring = curBoring, f.isBoring(m)
+		prevBoring, curBoring = curBoring, f.isBoring(m, len(mdent))
 
 		if i != 0 && !(prevBoring && curBoring) {
 			io.WriteString(w, "\n")
 		}
 
 		f.indentComments(w, m.Comments().Before, mdent, false)
-		fmt.Fprint(w, mdent, m.Key.JSON(), f.objSep(m.Value))
+		fmt.Fprint(w, mdent, m.Key.JSON(), f.objSep(m.Value, len(mdent)))
 
 		if len(m.Value.Comments().Before) == 0 {
 			f.formatValue(w, m.Value, "", mdent, false)
@@ -186,8 +214,8 @@ func (f Formatter) formatObject(w writeFlusher, o *Object, init, indent string) 
 // objSep returns a key-value separator for the given value.
 // Boring values get indented so they line up in columns;
 // non-boring values are stapled directly to the key.
-func (f Formatter) objSep(v Value) string {
-	if f.isBoring(v) {
+func (f Formatter) objSep(v Value, ilen int) string {
+	if f.isBoring(v, ilen) {
 		return ":\t"
 	}
 	return ": "
@@ -205,31 +233,41 @@ func (Formatter) canInlineComment(ss []string) bool {
 }
 
 // isBoring reports whether v has a simple enough structure that it can be
-// rendered on one line.
-func (f Formatter) isBoring(v Value) bool {
+// rendered on one line, assuming the target line begins indented by ilen
+// bytes.
+func (f Formatter) isBoring(v Value, ilen int) bool {
 	com := v.Comments()
 	switch t := v.(type) {
 	case *Array:
-		if len(com.End) != 0 {
+		if len(com.Before) != 0 || len(com.End) != 0 {
 			return false
 		}
-		for i, v := range t.Values {
-			if !f.isBoring(v) || len(v.Comments().Before) != 0 || i >= f.maxLineItems() {
-				return false
+		if slices.ContainsFunc(t.Values, func(elt Value) bool {
+			return !f.isBoring(elt, ilen) || len(elt.Comments().Before) != 0
+		}) {
+			return false // something in there is not boring enough
+		}
+		if m := f.maxInlineArrayElements(); m > 0 && len(t.Values) > m {
+			return false // too many items
+		}
+		if m := f.maxInlineArrayLength(); m > 0 {
+			// Note: Include ilen, the indentation prior to the array.
+			if elen := f.estimatedLength(t); elen+ilen+len(com.Line) > m {
+				return false // too long for a line
 			}
 		}
 		return true
 	case *Datum:
 		return t.Comments().IsEmpty()
 	case *Member:
-		return len(com.Before) == 0 && len(com.End) == 0 && f.isBoring(t.Value)
+		return len(com.Before) == 0 && len(com.End) == 0 && f.isBoring(t.Value, ilen)
 	case *Object:
 		if len(com.Before) != 0 || len(com.End) != 0 {
 			return false
 		}
 		if len(t.Members) == 1 {
 			m0 := t.Members[0]
-			return m0.Comments().IsEmpty() && m0.Value.Comments().IsEmpty() && f.isBoring(m0.Value)
+			return m0.Comments().IsEmpty() && m0.Value.Comments().IsEmpty() && f.isBoring(m0.Value, ilen)
 		}
 		return len(t.Members) == 0
 	default:
@@ -249,6 +287,66 @@ func (f Formatter) indentComments(w writeFlusher, ss []string, indent string, in
 		}
 		fmt.Fprint(w, indentComment(s, indent), "\n")
 	}
+}
+
+// estimatedLength reports an estimate of how long v would be if formatted in a
+// single line of text, ignoring comments.  The estimate may be somewhat higher
+// or lower than the real value.
+func (f Formatter) estimatedLength(v Value) int {
+	switch v := v.(type) {
+	case *Array:
+		var elen int
+		if len(v.Values) != 0 {
+			for _, elt := range v.Values {
+				elen += f.estimatedLength(elt)
+			}
+			elen += 2 * (len(v.Values) - 1) // for the ", " between elements
+		}
+		return elen + 2 // +2 for "[" and "]"
+
+	case *Object:
+		var elen int
+		if len(v.Members) != 0 {
+			for _, mem := range v.Members {
+				elen += f.estimatedLength(mem)
+			}
+			elen += 2 * (len(v.Members) - 1) // for the ", " between members
+		}
+		return elen + 2 // +2 for "{" and "}"
+
+	case *Member:
+		return len(v.Key.JSON()) + len(": ") + f.estimatedLength(v.Value)
+
+	case *Datum:
+		var nbuf [32]byte
+		switch t := v.Value.(type) {
+		case ast.Text:
+			// Don't swizzle quotations here, this is close enough.
+			// If it's from the parser, it's accurate; otherwise it is short by
+			// the quotation marks and whatever escapes might be needed.
+			// That could be a lot if it's a weird string, but that is uncommon.
+			return len(t.Spelling())
+		case ast.Bool:
+			return value.Cond(t, len("true"), len("false"))
+		case ast.Int:
+			buf := strconv.AppendInt(nbuf[:0], int64(t), 10)
+			return len(buf)
+		case ast.Float:
+			buf := strconv.AppendFloat(nbuf[:0], float64(t), 'g', -1, 64)
+			return len(buf)
+		case ast.Number:
+			return len(t.JSON()) // this should be a rawNumber, so already formatted
+		default:
+			if t == ast.Null {
+				return len("null")
+			}
+		}
+		// fall through in case of something unexpected
+
+	case *Document:
+		return f.estimatedLength(v.Value)
+	}
+	return 0 // shouldn't happen, but fail gracefully
 }
 
 // indentComment realigns comment text from s and indents it by indent.

--- a/jwcc/jwcc_test.go
+++ b/jwcc/jwcc_test.go
@@ -3,6 +3,7 @@
 package jwcc_test
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -126,6 +127,147 @@ func TestArrayOf(t *testing.T) {
 			t.Errorf("ArrayOf mixed (-got, +want):\n%s", diff)
 		}
 	})
+}
+
+func TestFormatOptions(t *testing.T) {
+	setComment := func(v jwcc.Value, text string) jwcc.Value {
+		v.Comments().Line = text
+		return v
+	}
+	tests := []struct {
+		name  string
+		input jwcc.Value
+		opts  jwcc.Formatter
+		want  string
+	}{
+		{
+			name:  "default_array_3",
+			input: jwcc.ArrayOf("a", "b", "c"),
+			opts:  jwcc.Formatter{},
+			want:  `["a", "b", "c"]`,
+		},
+		{
+			name:  "default_array_4",
+			input: jwcc.ArrayOf(1, 2, 3, 4),
+			opts:  jwcc.Formatter{},
+			want:  "[\n  1,\n  2,\n  3,\n  4,\n]",
+		},
+		{
+			name:  "count_4_array_3",
+			input: jwcc.ArrayOf("a", "b", "c"),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 4},
+			want:  `["a", "b", "c"]`,
+		},
+		{
+			name:  "count_2_array_3",
+			input: jwcc.ArrayOf(1, 2, 3),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 2},
+			want:  "[\n  1,\n  2,\n  3,\n]",
+		},
+		{
+			name:  "count_0_length_10_short",
+			input: jwcc.ArrayOf("a", "b"),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 10},
+			want:  `["a", "b"]`,
+		},
+		{
+			name:  "count_0_length_10_commented",
+			input: setComment(jwcc.ArrayOf(25, 37), "Something to say"),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 10},
+			want:  "[\n  25,\n  37,\n]   // Something to say\n",
+		},
+		{
+			name:  "count_0_length_50_commented",
+			input: setComment(jwcc.ArrayOf(25, 37), "Something to say"),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 50},
+			want:  "[25, 37] // Something to say\n",
+		},
+		{
+			name:  "count_0_length_10_long",
+			input: jwcc.ArrayOf(12345, 67890, 23456),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 10},
+			want:  "[\n  12345,\n  67890,\n  23456,\n]",
+		},
+		{
+			name:  "count_0_length_90_array_5",
+			input: jwcc.ArrayOf("alpha", "bravo", "charlie", "delta", "echo", "foxtrot"),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 90},
+			want:  `["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]`,
+		},
+		{
+			name:  "count_4_length_90_array_5",
+			input: jwcc.ArrayOf(1, 2, 3, 4, 5),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 4, MaxInlineArrayLength: 90},
+			want:  "[\n  1,\n  2,\n  3,\n  4,\n  5,\n]",
+		},
+		{
+			name:  "Nested/count_4_array_3",
+			input: jwcc.ObjectOf(jwcc.Field("foo", jwcc.ArrayOf("a", "b", "c"))),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 4},
+			want:  `{"foo": ["a", "b", "c"]}`,
+		},
+		{
+			name:  "Nested/count_2_array_3",
+			input: jwcc.ObjectOf(jwcc.Field("foo", jwcc.ArrayOf(1, 2, 3))),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 2},
+			want:  "{\n  \"foo\": [\n    1,\n    2,\n    3,\n  ],\n}",
+		},
+		{
+			name:  "Nested/count_0_length_10_short",
+			input: jwcc.ObjectOf(jwcc.Field("foo", jwcc.ArrayOf("a", "b"))),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 10},
+			want:  `{"foo": ["a", "b"]}`,
+		},
+		{
+			name:  "Nested/count_0_length_10_commented",
+			input: jwcc.ObjectOf(jwcc.Field("foo", setComment(jwcc.ArrayOf(23, 37), "history and tradition"))),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 10},
+			want:  "{\n  \"foo\": [\n    23,\n    37,\n  ], // history and tradition\n}",
+		},
+		{
+			name:  "Nested/count_0_length_50_commented",
+			input: jwcc.ObjectOf(jwcc.Field("foo", setComment(jwcc.ArrayOf(25, 37), "history and tradition"))),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 50},
+			want:  "{\n  \"foo\": [25, 37], // history and tradition\n}",
+		},
+		{
+			name:  "Nested/count_0_length_90_array_5",
+			input: jwcc.ObjectOf(jwcc.Field("foo", jwcc.ArrayOf("apple", "pear", "plum", "cherry", "quince"))),
+			opts:  jwcc.Formatter{MaxInlineArrayLength: 90},
+			want:  `{"foo": ["apple", "pear", "plum", "cherry", "quince"]}`,
+		},
+		{
+			name: "Nested/count_0_length_90_array_5_commented",
+			input: jwcc.ObjectOf(jwcc.Field("foo", setComment(
+				jwcc.ArrayOf(123, 456, 789, 1011, 1213), "no laws just vibes"))),
+			opts: jwcc.Formatter{MaxInlineArrayLength: 90},
+			want: "{\n  \"foo\": [123, 456, 789, 1011, 1213], // no laws just vibes\n}",
+		},
+		{
+			name: "Nested/count_0_length_20_array_5_commented",
+			input: jwcc.ObjectOf(jwcc.Field("foo", setComment(
+				jwcc.ArrayOf(123, 456, 789, 1011, 1213), "no laws just vibes"))),
+			opts: jwcc.Formatter{MaxInlineArrayLength: 20},
+			want: "{\n  \"foo\": [\n    123,\n    456,\n    789,\n    1011,\n    1213,\n  ], // no laws just vibes\n}",
+		},
+		{
+			name:  "Nested/count_4_length_90_array_5",
+			input: jwcc.ObjectOf(jwcc.Field("foo", jwcc.ArrayOf(1, 2, 3, 4, 5))),
+			opts:  jwcc.Formatter{MaxInlineArrayElements: 4, MaxInlineArrayLength: 90},
+			want:  "{\n  \"foo\": [\n    1,\n    2,\n    3,\n    4,\n    5,\n  ],\n}",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tc.opts.Format(&buf, tc.input); err != nil {
+				t.Fatalf("Format input %+v: unexpected error: %v", tc.input, err)
+			}
+			if diff := cmp.Diff(buf.String(), tc.want); diff != "" {
+				t.Errorf("Format %+v (-got, +want):\n%s", tc.input, diff)
+			}
+		})
+	}
 }
 
 func TestCleanComments(t *testing.T) {


### PR DESCRIPTION
When MaxInlineArrayElements is positive, it is the bound for number of array
elements to be rendered on one line.

When MaxInlineArrayLength is positive, it is tne bound for length of array
elements to be rendered on one line. Zero or negative means "no limit".

If both values are positive, both apply. However, if both are zero, the default
for MaxInlineArrayElements is 3, so that a zero-valued Formatter will continue
to inline arrays as prior to this change.

Add a bunch of tests.
